### PR TITLE
fix: Corregir configuración de Netlify para deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  publish = "build"
+  base = "web"
+  publish = "web/build"
   command = "npm run build"
 
 [[redirects]]


### PR DESCRIPTION
🔧 Mover netlify.toml a la raíz del proyecto
🔧 Configurar base directory como 'web'
🔧 Corregir publish directory a 'web/build'

Esto debería resolver el error 404 en Netlify