### PR TITLE
Enable automatic Windows NTLM authentication in proxy server - Update…

### DIFF
--- a/proxy_requirements.txt
+++ b/proxy_requirements.txt
@@ -1,3 +1,4 @@
 flask==2.3.3
 flask-cors==4.0.0
 requests==2.31.0
+requests-ntlm==1.2.0


### PR DESCRIPTION
…d proxy_server.py to use automatic Windows credentials - Added requests-ntlm for seamless authentication - Proxy now uses current user's Windows credentials automatically - Fixes 401 Unauthorized errors - Ready for production testing with Netlify web app